### PR TITLE
Fixed syntax ready for puppet 4.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class unattended_upgrades(
     ensure  => file,
     owner   => root,
     group   => root,
-    mode    => 0644,
+    mode    => '0644',
     content => template('unattended_upgrades/unattended-upgrades.erb'),
   }
 
@@ -35,7 +35,7 @@ class unattended_upgrades(
     ensure  => file,
     owner   => root,
     group   => root,
-    mode    => 0644,
+    mode    => '0644',
     content => template('unattended_upgrades/auto-upgrades.erb')
   }
 


### PR DESCRIPTION
Fixed unquoted numbers in 'mode' attribute for file as these must be
quoted when puppet 4.0. Leaving them unquoted raises depreciation
warnings on puppet 3.7  when the catalogue is compiled, though not a
fatal error, best its fixed up before anyone migrates to puppet 4.0.

Deprecation warning was detected with puppet 3.8 with future parser
enabled.
