### PR TITLE
Add support for overriding origins

### DIFF
--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -1,7 +1,7 @@
 // Automatically upgrade packages from these origin patterns
 Unattended-Upgrade::Origins-Pattern {
 <% scope['unattended_upgrades::repos'].each do |repo, opts| -%>
-        "origin=${distro_id},archive=<%= repo %><% if (defined? opts) %>,label=<%= opts['label'] %><% end %>";
+        "origin=<% if (defined? opts and opts['origin'] and opts['origin'] != '') %><%= opts['origin'] %><% else %>${distro_id}<% end %>,archive=<%= repo %><% if (defined? opts) %>,label=<%= opts['label'] %><% end %>";
 <% end %>
 }; 
 


### PR DESCRIPTION
Enable repository origin to be overridden - useful e.g. to update the Puppetlabs repository itself since it is tagged with origin='Puppetlabs' instead of the ${distro_id}
