### PR TITLE
Directly specify origin patterns

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 class unattended_upgrades(
+  $ensure                       = 'installed'
   $period                       = 1,                                             # Update period (in days)
-  $repos                        = {},                                            # Repos to upgrade
+  $origin                       = [],                                            # Origin patterns
   $blacklist                    = [],                                            # Packages to not update
   $email                        = '',                                            # Email for update status
   $autofix                      = true,                                          # Ensure updates keep getting installed
@@ -17,12 +18,12 @@ class unattended_upgrades(
   $apt_path = '/etc/apt/apt.conf.d/20auto-upgrades'
   $package = 'unattended-upgrades'
 
-  if $::operatingsystem !~ /^(Debian|Ubuntu)$/ {
-    fail("${::operatingsystem} is not supported.")
+  if $::osfamily != 'Debian' {
+    fail("${::osfamily} is not supported.")
   }
 
   package { $package:
-    ensure => latest,
+    ensure => $ensure,
   }
 
   file { $conf_path:
@@ -42,7 +43,6 @@ class unattended_upgrades(
   }
 
   service { $package:
-    ensure    => running,
     subscribe => [ File[$conf_path], File[$apt_path], Package[$package], ],
   }
 }

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -1,8 +1,8 @@
 // Automatically upgrade packages from these origin patterns
 Unattended-Upgrade::Origins-Pattern {
-<% scope['unattended_upgrades::repos'].each do |repo, opts| -%>
-        "origin=${distro_id},archive=<%= repo %><% if (defined? opts) %>,label=<%= opts['label'] %><% end %>";
-<% end %>
+<%- scope['unattended_upgrades::origins'].each do |origin| -%>
+        "<%= origin %>";
+<%- end -%>
 }; 
 
 // List of packages to not update


### PR DESCRIPTION
These changes replace the repos object parameter by an origin array parameter, which simply lists the origin patterns.

Additionally the service has been removed to prevent puppet from always trying to start the service, the subscription should be enough.
